### PR TITLE
Refactor leaf handler boundaries

### DIFF
--- a/src/features/Code/CodeCard/ui/CodeCardHeader.tsx
+++ b/src/features/Code/CodeCard/ui/CodeCardHeader.tsx
@@ -12,7 +12,6 @@
  */
 
 import { useAtomValue, useSetAtom } from 'jotai';
-import type React from 'react';
 import { useMemo } from 'react';
 import { activeActivityPageIdAtom } from '@/app/model/activityPageAtoms';
 import { filesAtom, viewModeAtom } from '@/entities/AppView/model/atoms';
@@ -68,10 +67,6 @@ const CodeCardHeader = ({ node }: { node: CanvasNode }) => {
     setFocusedNodeId(node.id);
   }
 
-  function handleToggleLevel(e: React.MouseEvent) {
-    toggleLevel(e);
-  }
-
   return (
     <div
       className="px-3 py-1.5 border-b border-white/5 flex justify-between items-center bg-black/20 cursor-pointer"
@@ -80,7 +75,7 @@ const CodeCardHeader = ({ node }: { node: CanvasNode }) => {
     >
       <div className="flex items-center gap-2 overflow-hidden">
         {/* Fold Level Toggle Button */}
-        <FoldLevelButton currentLevel={currentLevel} onToggle={handleToggleLevel} disabled={!canFold} />
+        <FoldLevelButton currentLevel={currentLevel} toggleLevel={toggleLevel} disabled={!canFold} />
 
         {/* Node Icon */}
         <iconConfig.Icon className={`w-4 h-4 ${iconConfig.color}`} />

--- a/src/features/Code/CodeCard/ui/FoldLevelButton.tsx
+++ b/src/features/Code/CodeCard/ui/FoldLevelButton.tsx
@@ -12,8 +12,8 @@ import type { FoldLevel } from '../hooks/useFoldLevel';
 export interface FoldLevelButtonProps {
   /** 현재 Fold 레벨 */
   currentLevel: FoldLevel;
-  /** 토글 핸들러 */
-  onToggle: (e: React.MouseEvent) => void;
+  /** Fold 레벨 변경 command */
+  toggleLevel: (e: React.MouseEvent) => void;
   /** 비활성화 여부 */
   disabled?: boolean;
 }
@@ -44,13 +44,13 @@ function getFoldTooltip(level: FoldLevel): string {
  *
  * <FoldLevelButton
  *   currentLevel={currentLevel}
- *   onToggle={toggleLevel}
+ *   toggleLevel={toggleLevel}
  *   disabled={!canFold}
  * />
  */
-export function FoldLevelButton({ currentLevel, onToggle, disabled = false }: FoldLevelButtonProps) {
+export function FoldLevelButton({ currentLevel, toggleLevel, disabled = false }: FoldLevelButtonProps) {
   function handleClick(e: React.MouseEvent) {
-    onToggle(e);
+    toggleLevel(e);
   }
 
   if (disabled) return null;

--- a/src/features/Code/CodeViewer/ui/TemplateClickableSegment.tsx
+++ b/src/features/Code/CodeViewer/ui/TemplateClickableSegment.tsx
@@ -1,0 +1,26 @@
+import type React from 'react';
+import { useEditorTheme } from '@/entities/AppTheme/EditorThemeProvider';
+
+interface TemplateClickableSegmentProps {
+  text: string;
+  nodeId: string;
+  expandToken: (nodeId: string, forceExpand: boolean) => void;
+}
+
+export function TemplateClickableSegment({ text, nodeId, expandToken }: TemplateClickableSegmentProps) {
+  const theme = useEditorTheme();
+
+  function handleClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    expandToken(nodeId, e.metaKey || e.ctrlKey);
+  }
+
+  return (
+    <span
+      onClick={handleClick}
+      className={`inline-block px-0.5 rounded transition-all duration-200 select-text cursor-pointer border ${theme.colors.template.clickable.bg} ${theme.colors.template.clickable.border} ${theme.colors.template.clickable.text} ${theme.colors.template.clickable.hoverBg} ${theme.colors.template.clickable.hoverBorder}`}
+    >
+      {text}
+    </span>
+  );
+}

--- a/src/features/Code/CodeViewer/ui/VueTemplateSection.tsx
+++ b/src/features/Code/CodeViewer/ui/VueTemplateSection.tsx
@@ -6,13 +6,13 @@
  */
 
 import { useAtomValue, useSetAtom } from 'jotai';
-import type React from 'react';
 import { useMemo } from 'react';
 import { useEditorTheme } from '@/entities/AppTheme/EditorThemeProvider';
 import { filesAtom, fullNodeMapAtom } from '@/entities/AppView/model/atoms';
 import type { CanvasNode } from '@/entities/CanvasNode/model/types';
 import { lastExpandedIdAtom, visibleNodeIdsAtom } from '@/features/Canvas/model/atoms';
 import { extractTemplateComponents, extractTemplateVariables } from '@/shared/tsParser/utils/vueTemplateParser';
+import { TemplateClickableSegment } from './TemplateClickableSegment';
 
 const VueTemplateSection = ({
   template,
@@ -124,12 +124,8 @@ const VueTemplateSection = ({
     });
   }, [template, node.dependencies, node.filePath, scriptEndLine, files]);
 
-  function handleTokenClick(nodeId: string, e: React.MouseEvent) {
-    e.stopPropagation();
-
+  function expandToken(nodeId: string, forceExpand: boolean) {
     if (!fullNodeMap.has(nodeId)) return;
-
-    const forceExpand = e.metaKey || e.ctrlKey;
 
     setVisibleNodeIds((prev: Set<string>) => {
       const next = new Set(prev);
@@ -161,31 +157,6 @@ const VueTemplateSection = ({
     setLastExpandedId(nodeId);
   }
 
-  function TemplateClickableSegment({
-    segment,
-  }: {
-    segment: {
-      text: string;
-      isClickable?: boolean;
-      nodeId?: string;
-    };
-  }) {
-    function handleClick(e: React.MouseEvent) {
-      if (segment.nodeId) {
-        handleTokenClick(segment.nodeId, e);
-      }
-    }
-
-    return (
-      <span
-        onClick={handleClick}
-        className={`inline-block px-0.5 rounded transition-all duration-200 select-text cursor-pointer border ${theme.colors.template.clickable.bg} ${theme.colors.template.clickable.border} ${theme.colors.template.clickable.text} ${theme.colors.template.clickable.hoverBg} ${theme.colors.template.clickable.hoverBorder}`}
-      >
-        {segment.text}
-      </span>
-    );
-  }
-
   return (
     <div className="flex flex-col">
       {templateLines.map((line, idx) => (
@@ -203,7 +174,14 @@ const VueTemplateSection = ({
           >
             {line.segments.map((seg, segIdx) => {
               if (seg.isClickable && seg.nodeId) {
-                return <TemplateClickableSegment key={segIdx} segment={seg} />;
+                return (
+                  <TemplateClickableSegment
+                    key={segIdx}
+                    text={seg.text}
+                    nodeId={seg.nodeId}
+                    expandToken={expandToken}
+                  />
+                );
               }
 
               return (

--- a/src/features/Debug/JotaiDevTools/ui/JotaiDevTools.tsx
+++ b/src/features/Debug/JotaiDevTools/ui/JotaiDevTools.tsx
@@ -3,8 +3,7 @@
  */
 
 import type { Atom } from 'jotai';
-import { ChevronDown } from 'lucide-react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as themeAtoms from '@/entities/AppTheme/atoms';
 import * as appAtoms from '@/entities/AppView/model/atoms';
 import { store } from '@/entities/AppView/model/store';
@@ -16,6 +15,8 @@ import * as explorerAtoms from '@/features/Explorer/model/atoms';
 import * as navigationAtoms from '@/features/File/Navigation/model/atoms';
 import * as filesAtoms from '@/features/File/OpenFiles/model/atoms';
 import * as searchAtoms from '@/features/Search/UnifiedSearch/model/atoms';
+import { JotaiDevToolsOpenButton } from './JotaiDevToolsOpenButton';
+import { type AtomUpdate, JotaiDevToolsPanel } from './JotaiDevToolsPanel';
 
 // Combine all atoms for DevTools tracking
 const atoms = {
@@ -30,13 +31,6 @@ const atoms = {
   ...canvasAtoms,
   ...explorerAtoms,
 };
-
-interface AtomUpdate {
-  name: string;
-  value: unknown;
-  timestamp: number;
-  id: string; // unique id for each update
-}
 
 const JotaiDevTools = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -113,100 +107,19 @@ const JotaiDevTools = () => {
     return null;
   }
 
-  function handleOpenClick() {
+  function openDevTools() {
     setIsOpen(true);
   }
 
-  function handleCloseClick() {
+  function closeDevTools() {
     setIsOpen(false);
   }
 
   if (!isOpen) {
-    return (
-      <button
-        onClick={handleOpenClick}
-        className="fixed top-4 right-4 bg-purple-600 hover:bg-purple-700 text-white px-3 py-2 rounded-lg shadow-lg text-xs font-semibold transition-colors z-50"
-      >
-        Jotai DevTools
-      </button>
-    );
+    return <JotaiDevToolsOpenButton openDevTools={openDevTools} />;
   }
 
-  return (
-    <div className="fixed top-0 right-0 bg-slate-900/95 border-l border-slate-700 shadow-2xl w-96 h-screen overflow-hidden flex flex-col z-50 backdrop-blur-sm">
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 bg-slate-800 border-b border-slate-700 flex-shrink-0">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold text-purple-400">Jotai DevTools</span>
-          <span className="text-2xs text-slate-500">({updateHistory.length} updates)</span>
-        </div>
-        <button onClick={handleCloseClick} className="text-slate-400 hover:text-slate-200 transition-colors">
-          <ChevronDown className="w-4 h-4" />
-        </button>
-      </div>
-
-      {/* Update History - Most Recent First */}
-      <div className="flex-1 overflow-y-auto px-3 py-2">
-        {updateHistory.length === 0 ? (
-          <div className="text-xs text-slate-500 text-center py-4">No updates yet</div>
-        ) : (
-          <div className="space-y-1">
-            {updateHistory.map((update, index) => (
-              <AtomUpdateItem key={update.id} update={update} isFirst={index === 0} />
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-};
-
-const AtomUpdateItem: React.FC<{ update: AtomUpdate; isFirst: boolean }> = ({ update, isFirst }) => {
-  const { name, value, timestamp } = update;
-
-  const valuePreview = React.useMemo(() => {
-    try {
-      if (value === null) return 'null';
-      if (value === undefined) return 'undefined';
-      if (typeof value === 'string') return value.length > 50 ? `"${value.substring(0, 50)}..."` : `"${value}"`;
-      if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-      if (typeof value === 'function') return '[Function]';
-      if (Array.isArray(value)) return `Array(${value.length})`;
-      if (value instanceof Set) return `Set(${value.size})`;
-      if (value instanceof Map) return `Map(${value.size})`;
-      if (typeof value === 'object') {
-        const keys = Object.keys(value);
-        if (keys.length === 0) return '{}';
-        if (keys.length <= 2) {
-          return `{${keys.join(', ')}}`;
-        }
-        return `{${keys.length} keys}`;
-      }
-      return String(value);
-    } catch {
-      return '[Error]';
-    }
-  }, [value]);
-
-  const timeStr = new Date(timestamp).toLocaleTimeString('en-US', {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    fractionalSecondDigits: 3,
-  });
-
-  return (
-    <div
-      className={`flex items-center justify-between gap-2 px-2 py-1 rounded ${isFirst ? 'bg-purple-900/30 border border-purple-500/50' : 'bg-slate-800/50 border border-slate-700/50'}`}
-    >
-      <div className="flex items-center gap-2 flex-1 min-w-0">
-        <div className="text-[9px] text-slate-500 font-mono flex-shrink-0">{timeStr}</div>
-        <div className="text-2xs font-semibold text-purple-300 flex-shrink-0">{name}</div>
-      </div>
-      <div className="text-2xs text-slate-400 font-mono truncate flex-shrink-0 max-w-[150px]">{valuePreview}</div>
-    </div>
-  );
+  return <JotaiDevToolsPanel updateHistory={updateHistory} closeDevTools={closeDevTools} />;
 };
 
 export default JotaiDevTools;

--- a/src/features/Debug/JotaiDevTools/ui/JotaiDevToolsOpenButton.tsx
+++ b/src/features/Debug/JotaiDevTools/ui/JotaiDevToolsOpenButton.tsx
@@ -1,0 +1,18 @@
+interface JotaiDevToolsOpenButtonProps {
+  openDevTools: () => void;
+}
+
+export function JotaiDevToolsOpenButton({ openDevTools }: JotaiDevToolsOpenButtonProps) {
+  function handleClick() {
+    openDevTools();
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className="fixed top-4 right-4 bg-purple-600 hover:bg-purple-700 text-white px-3 py-2 rounded-lg shadow-lg text-xs font-semibold transition-colors z-50"
+    >
+      Jotai DevTools
+    </button>
+  );
+}

--- a/src/features/Debug/JotaiDevTools/ui/JotaiDevToolsPanel.tsx
+++ b/src/features/Debug/JotaiDevTools/ui/JotaiDevToolsPanel.tsx
@@ -1,0 +1,96 @@
+import { ChevronDown } from 'lucide-react';
+import React from 'react';
+
+export interface AtomUpdate {
+  name: string;
+  value: unknown;
+  timestamp: number;
+  id: string;
+}
+
+interface JotaiDevToolsPanelProps {
+  updateHistory: AtomUpdate[];
+  closeDevTools: () => void;
+}
+
+export function JotaiDevToolsPanel({ updateHistory, closeDevTools }: JotaiDevToolsPanelProps) {
+  function handleCloseClick() {
+    closeDevTools();
+  }
+
+  return (
+    <div className="fixed top-0 right-0 bg-slate-900/95 border-l border-slate-700 shadow-2xl w-96 h-screen overflow-hidden flex flex-col z-50 backdrop-blur-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 bg-slate-800 border-b border-slate-700 flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-purple-400">Jotai DevTools</span>
+          <span className="text-2xs text-slate-500">({updateHistory.length} updates)</span>
+        </div>
+        <button onClick={handleCloseClick} className="text-slate-400 hover:text-slate-200 transition-colors">
+          <ChevronDown className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Update History - Most Recent First */}
+      <div className="flex-1 overflow-y-auto px-3 py-2">
+        {updateHistory.length === 0 ? (
+          <div className="text-xs text-slate-500 text-center py-4">No updates yet</div>
+        ) : (
+          <div className="space-y-1">
+            {updateHistory.map((update, index) => (
+              <AtomUpdateItem key={update.id} update={update} isFirst={index === 0} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const AtomUpdateItem: React.FC<{ update: AtomUpdate; isFirst: boolean }> = ({ update, isFirst }) => {
+  const { name, value, timestamp } = update;
+
+  const valuePreview = React.useMemo(() => {
+    try {
+      if (value === null) return 'null';
+      if (value === undefined) return 'undefined';
+      if (typeof value === 'string') return value.length > 50 ? `"${value.substring(0, 50)}..."` : `"${value}"`;
+      if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+      if (typeof value === 'function') return '[Function]';
+      if (Array.isArray(value)) return `Array(${value.length})`;
+      if (value instanceof Set) return `Set(${value.size})`;
+      if (value instanceof Map) return `Map(${value.size})`;
+      if (typeof value === 'object') {
+        const keys = Object.keys(value);
+        if (keys.length === 0) return '{}';
+        if (keys.length <= 2) {
+          return `{${keys.join(', ')}}`;
+        }
+        return `{${keys.length} keys}`;
+      }
+      return String(value);
+    } catch {
+      return '[Error]';
+    }
+  }, [value]);
+
+  const timeStr = new Date(timestamp).toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    fractionalSecondDigits: 3,
+  });
+
+  return (
+    <div
+      className={`flex items-center justify-between gap-2 px-2 py-1 rounded ${isFirst ? 'bg-purple-900/30 border border-purple-500/50' : 'bg-slate-800/50 border border-slate-700/50'}`}
+    >
+      <div className="flex items-center gap-2 flex-1 min-w-0">
+        <div className="text-[9px] text-slate-500 font-mono flex-shrink-0">{timeStr}</div>
+        <div className="text-2xs font-semibold text-purple-300 flex-shrink-0">{name}</div>
+      </div>
+      <div className="text-2xs text-slate-400 font-mono truncate flex-shrink-0 max-w-[150px]">{valuePreview}</div>
+    </div>
+  );
+};

--- a/src/features/Explorer/ui/RelatedFilesSection.tsx
+++ b/src/features/Explorer/ui/RelatedFilesSection.tsx
@@ -1,0 +1,40 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { FileExplorer } from '@/features/Explorer/ui/FileExplorer';
+
+interface RelatedFilesSectionProps {
+  title: string;
+  count: number;
+  files: Record<string, string>;
+}
+
+export function RelatedFilesSection({ title, count, files }: RelatedFilesSectionProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  function handleToggle() {
+    setIsCollapsed(!isCollapsed);
+  }
+
+  return (
+    <div className={isCollapsed ? '' : 'flex-1 flex flex-col overflow-hidden'}>
+      <button
+        onClick={handleToggle}
+        className="flex w-full h-8 items-center justify-between border-b border-border-DEFAULT px-2 flex-shrink-0 hover:bg-bg-deep transition-colors"
+      >
+        <span className="text-2xs font-medium text-text-tertiary normal-case">
+          {title} ({count})
+        </span>
+        {isCollapsed ? (
+          <ChevronRight className="w-3 h-3 text-text-muted" />
+        ) : (
+          <ChevronDown className="w-3 h-3 text-text-muted" />
+        )}
+      </button>
+      {!isCollapsed && (
+        <div className="flex-1 overflow-hidden">
+          <FileExplorer filteredFiles={files} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/Explorer/ui/RelatedFilesView.tsx
+++ b/src/features/Explorer/ui/RelatedFilesView.tsx
@@ -4,21 +4,17 @@
  */
 
 import { useAtomValue } from 'jotai';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { filesAtom, fullNodeMapAtom } from '@/entities/AppView/model/atoms';
 import { getDependencies, getDependents } from '@/entities/SourceFileNode/lib/getters';
-import { FileExplorer } from '@/features/Explorer/ui/FileExplorer';
 import { activeTabAtom } from '@/features/File/OpenFiles/model/atoms';
 import { resolvePath } from '@/shared/tsParser/utils/pathResolver';
+import { RelatedFilesSection } from './RelatedFilesSection';
 
 export function RelatedFilesView() {
   const files = useAtomValue(filesAtom);
   const fullNodeMap = useAtomValue(fullNodeMapAtom);
   const activeTab = useAtomValue(activeTabAtom);
-
-  const [isDependenciesCollapsed, setIsDependenciesCollapsed] = useState(false);
-  const [isDependentsCollapsed, setIsDependentsCollapsed] = useState(false);
 
   // Calculate dependencies and dependents for active file
   const { dependencies, dependents } = useMemo(() => {
@@ -78,62 +74,16 @@ export function RelatedFilesView() {
     );
   }
 
-  function handleDependenciesToggle() {
-    setIsDependenciesCollapsed(!isDependenciesCollapsed);
-  }
-
-  function handleDependentsToggle() {
-    setIsDependentsCollapsed(!isDependentsCollapsed);
-  }
-
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Dependencies Section */}
       {dependencies.length > 0 && (
-        <div className={isDependenciesCollapsed ? '' : 'flex-1 flex flex-col overflow-hidden'}>
-          <button
-            onClick={handleDependenciesToggle}
-            className="flex w-full h-8 items-center justify-between border-b border-border-DEFAULT px-2 flex-shrink-0 hover:bg-bg-deep transition-colors"
-          >
-            <span className="text-2xs font-medium text-text-tertiary normal-case">
-              Dependencies ({dependencies.length})
-            </span>
-            {isDependenciesCollapsed ? (
-              <ChevronRight className="w-3 h-3 text-text-muted" />
-            ) : (
-              <ChevronDown className="w-3 h-3 text-text-muted" />
-            )}
-          </button>
-          {!isDependenciesCollapsed && (
-            <div className="flex-1 overflow-hidden">
-              <FileExplorer filteredFiles={dependenciesFiles} />
-            </div>
-          )}
-        </div>
+        <RelatedFilesSection title="Dependencies" count={dependencies.length} files={dependenciesFiles} />
       )}
 
       {/* Dependents Section */}
       {dependents.length > 0 && (
-        <div className={isDependentsCollapsed ? '' : 'flex-1 flex flex-col overflow-hidden'}>
-          <button
-            onClick={handleDependentsToggle}
-            className="flex w-full h-8 items-center justify-between border-b border-border-DEFAULT px-2 flex-shrink-0 hover:bg-bg-deep transition-colors"
-          >
-            <span className="text-2xs font-medium text-text-tertiary normal-case">
-              Dependents ({dependents.length})
-            </span>
-            {isDependentsCollapsed ? (
-              <ChevronRight className="w-3 h-3 text-text-muted" />
-            ) : (
-              <ChevronDown className="w-3 h-3 text-text-muted" />
-            )}
-          </button>
-          {!isDependentsCollapsed && (
-            <div className="flex-1 overflow-hidden">
-              <FileExplorer filteredFiles={dependentsFilesRecord} />
-            </div>
-          )}
-        </div>
+        <RelatedFilesSection title="Dependents" count={dependents.length} files={dependentsFilesRecord} />
       )}
     </div>
   );

--- a/src/features/Explorer/ui/WorkspaceFileButton.tsx
+++ b/src/features/Explorer/ui/WorkspaceFileButton.tsx
@@ -1,0 +1,31 @@
+import { useOpenFile } from '@/features/File/OpenFiles/lib/useOpenFile';
+import { getFileName } from '@/shared/pathUtils';
+import { FileIcon } from '@/shared/ui/FileIcon';
+
+interface WorkspaceFileButtonProps {
+  filePath: string;
+  activeTab: string | null;
+}
+
+export function WorkspaceFileButton({ filePath, activeTab }: WorkspaceFileButtonProps) {
+  const fileName = getFileName(filePath);
+  const isActive = filePath === activeTab;
+  const { openFile } = useOpenFile();
+
+  function handleClick() {
+    openFile(filePath);
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-bg-deep transition-colors ${
+        isActive ? 'bg-bg-deep text-text-primary' : 'text-text-secondary'
+      }`}
+      title={filePath}
+    >
+      <FileIcon fileName={fileName} size={16} />
+      <span className="truncate">{fileName}</span>
+    </button>
+  );
+}

--- a/src/features/Explorer/ui/WorkspacePanel.tsx
+++ b/src/features/Explorer/ui/WorkspacePanel.tsx
@@ -6,38 +6,8 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { X } from 'lucide-react';
 import { rightPanelOpenAtom } from '@/entities/AppView/model/atoms';
-import { useOpenFile } from '@/features/File/OpenFiles/lib/useOpenFile';
 import { activeTabAtom, openedTabsAtom } from '@/features/File/OpenFiles/model/atoms';
-import { getFileName } from '@/shared/pathUtils';
-import { FileIcon } from '@/shared/ui/FileIcon';
-
-interface WorkspaceFileButtonProps {
-  filePath: string;
-  activeTab: string | null;
-}
-
-function WorkspaceFileButton({ filePath, activeTab }: WorkspaceFileButtonProps) {
-  const fileName = getFileName(filePath);
-  const isActive = filePath === activeTab;
-  const { openFile } = useOpenFile();
-
-  function handleClick() {
-    openFile(filePath);
-  }
-
-  return (
-    <button
-      onClick={handleClick}
-      className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left hover:bg-bg-deep transition-colors ${
-        isActive ? 'bg-bg-deep text-text-primary' : 'text-text-secondary'
-      }`}
-      title={filePath}
-    >
-      <FileIcon fileName={fileName} size={16} />
-      <span className="truncate">{fileName}</span>
-    </button>
-  );
-}
+import { WorkspaceFileButton } from './WorkspaceFileButton';
 
 export function WorkspacePanel() {
   const openedTabs = useAtomValue(openedTabsAtom);

--- a/src/features/File/OpenFiles/ui/IDEScrollView/ui/FileNavButton.tsx
+++ b/src/features/File/OpenFiles/ui/IDEScrollView/ui/FileNavButton.tsx
@@ -1,0 +1,38 @@
+import { getFileName } from '@/shared/pathUtils.ts';
+import { FileIcon } from '@/shared/ui/FileIcon';
+
+interface FileNavButtonProps {
+  filePath: string;
+  isActive: boolean;
+  selectFile: (filePath: string) => void;
+}
+
+export function FileNavButton({ filePath, isActive, selectFile }: FileNavButtonProps) {
+  const fileName = getFileName(filePath);
+
+  function handleClick() {
+    selectFile(filePath);
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className={`
+        flex items-center gap-2 px-3 py-2 text-left transition-colors
+        hover:bg-bg-hover
+        ${isActive ? 'bg-warm-500/10 border-l-2 border-warm-300' : 'border-l-2 border-transparent'}
+      `}
+    >
+      <FileIcon
+        fileName={fileName}
+        size={12}
+        className={`shrink-0 ${isActive ? 'text-warm-300' : 'text-text-tertiary'}`}
+      />
+      <div className="flex flex-col min-w-0">
+        <span className={`text-xs truncate ${isActive ? 'text-text-primary font-medium' : 'text-text-secondary'}`}>
+          {fileName}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/src/features/File/OpenFiles/ui/IDEScrollView/ui/FileNavPanel.tsx
+++ b/src/features/File/OpenFiles/ui/IDEScrollView/ui/FileNavPanel.tsx
@@ -3,22 +3,17 @@
  * 파일 목록 표시 및 스크롤 네비게이션
  */
 
-import { getFileName } from '@/shared/pathUtils.ts';
-import { FileIcon } from '@/shared/ui/FileIcon';
+import { FileNavButton } from './FileNavButton';
 
 const FileNavPanel = ({
   filePaths,
   currentFilePath,
-  onFileClick,
+  selectFile,
 }: {
   filePaths: string[];
   currentFilePath: string | null;
-  onFileClick: (filePath: string) => void;
+  selectFile: (filePath: string) => void;
 }) => {
-  function handleFileClick(filePath: string) {
-    onFileClick(filePath);
-  }
-
   return (
     <div className="w-48 border-l border-border-DEFAULT bg-bg-elevated overflow-y-auto">
       {/* 헤더 */}
@@ -33,50 +28,12 @@ const FileNavPanel = ({
             key={filePath}
             filePath={filePath}
             isActive={filePath === currentFilePath}
-            onFileClick={handleFileClick}
+            selectFile={selectFile}
           />
         ))}
       </div>
     </div>
   );
 };
-
-function FileNavButton({
-  filePath,
-  isActive,
-  onFileClick,
-}: {
-  filePath: string;
-  isActive: boolean;
-  onFileClick: (filePath: string) => void;
-}) {
-  const fileName = getFileName(filePath);
-
-  function handleClick() {
-    onFileClick(filePath);
-  }
-
-  return (
-    <button
-      onClick={handleClick}
-      className={`
-        flex items-center gap-2 px-3 py-2 text-left transition-colors
-        hover:bg-bg-hover
-        ${isActive ? 'bg-warm-500/10 border-l-2 border-warm-300' : 'border-l-2 border-transparent'}
-      `}
-    >
-      <FileIcon
-        fileName={fileName}
-        size={12}
-        className={`shrink-0 ${isActive ? 'text-warm-300' : 'text-text-tertiary'}`}
-      />
-      <div className="flex flex-col min-w-0">
-        <span className={`text-xs truncate ${isActive ? 'text-text-primary font-medium' : 'text-text-secondary'}`}>
-          {fileName}
-        </span>
-      </div>
-    </button>
-  );
-}
 
 export default FileNavPanel;

--- a/src/features/RefactoringPrompt/RefactoringPromptDialog.tsx
+++ b/src/features/RefactoringPrompt/RefactoringPromptDialog.tsx
@@ -13,14 +13,14 @@ import { generateRefactoringPrompt, type RefactoringPrompt } from './lib/promptG
 
 export interface RefactoringPromptDialogProps {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  changeOpen: (open: boolean) => void;
   selectedItemKeys: Set<string>;
   deadCodeResults: DeadCodeResults;
 }
 
 export function RefactoringPromptDialog({
   open,
-  onOpenChange,
+  changeOpen,
   selectedItemKeys,
   deadCodeResults,
 }: RefactoringPromptDialogProps) {
@@ -56,11 +56,11 @@ export function RefactoringPromptDialog({
   }
 
   function handleOpenChange(nextOpen: boolean) {
-    onOpenChange(nextOpen);
+    changeOpen(nextOpen);
   }
 
   function handleCloseClick() {
-    onOpenChange(false);
+    changeOpen(false);
   }
 
   if (!refactoringPrompt) return null;

--- a/src/pages/code-doc/features/CodeDocView/ui/DocViewer.tsx
+++ b/src/pages/code-doc/features/CodeDocView/ui/DocViewer.tsx
@@ -18,7 +18,7 @@ export const DocViewer = ({ data, layout }: DocViewerProps) => {
   const VISIBLE_IMPORTS = 8;
   const visibleImports = isDepsExpanded ? data.imports : data.imports.slice(0, VISIBLE_IMPORTS);
 
-  function handleDefinitionClick(startLine: number) {
+  function goToDefinition(startLine: number) {
     console.log('[DocViewer] Navigate to line:', startLine);
   }
 
@@ -99,7 +99,7 @@ export const DocViewer = ({ data, layout }: DocViewerProps) => {
 
       <div className="mb-32">
         {data.symbols?.map((symbol, idx) => (
-          <SymbolSection key={idx} symbol={symbol} layout={layout} onDefinitionClick={handleDefinitionClick} />
+          <SymbolSection key={idx} symbol={symbol} layout={layout} goToDefinition={goToDefinition} />
         ))}
       </div>
 

--- a/src/pages/code-doc/features/CodeDocView/ui/SymbolSection.tsx
+++ b/src/pages/code-doc/features/CodeDocView/ui/SymbolSection.tsx
@@ -14,8 +14,8 @@ const getStartLine = (lineStr?: string): number => {
 export const SymbolSection: React.FC<{
   symbol: SymbolDetail;
   layout: 'linear' | 'split';
-  onDefinitionClick?: (startLine: number) => void;
-}> = ({ symbol, layout, onDefinitionClick }) => {
+  goToDefinition?: (startLine: number) => void;
+}> = ({ symbol, layout, goToDefinition }) => {
   let TypeIcon = 'info';
   if (symbol.type === 'function') TypeIcon = 'function';
   if (symbol.type === 'interface') TypeIcon = 'interface';
@@ -25,14 +25,14 @@ export const SymbolSection: React.FC<{
   if (symbol.type === 'test-hook') TypeIcon = 'testHook';
 
   function handleDefinitionClick() {
-    if (symbol.startLine && onDefinitionClick) {
-      onDefinitionClick(symbol.startLine);
+    if (symbol.startLine && goToDefinition) {
+      goToDefinition(symbol.startLine);
     }
   }
 
-  function handleCodeLineClick(lineNumber: number) {
-    if (onDefinitionClick) {
-      onDefinitionClick(lineNumber);
+  function goToCodeLine(lineNumber: number) {
+    if (goToDefinition) {
+      goToDefinition(lineNumber);
     }
   }
 
@@ -275,7 +275,7 @@ export const SymbolSection: React.FC<{
                   const startLine = getStartLine(block.lines);
                   grouped.push(
                     <div key={idx}>
-                      <TextbookCodeBlock code={block.content} startLine={startLine} onLineClick={handleCodeLineClick} />
+                      <TextbookCodeBlock code={block.content} startLine={startLine} clickLine={goToCodeLine} />
                     </div>
                   );
                 }

--- a/src/pages/code-doc/features/CodeDocView/ui/TableOfContents.tsx
+++ b/src/pages/code-doc/features/CodeDocView/ui/TableOfContents.tsx
@@ -3,7 +3,7 @@ import { Icon } from './Icon';
 
 interface TableOfContentsItemProps {
   symbol: SymbolDetail;
-  onSelectSymbol: (symbolName: string) => void;
+  selectSymbol: (symbolName: string) => void;
 }
 
 function getSymbolIcon(symbol: SymbolDetail) {
@@ -16,11 +16,11 @@ function getSymbolIcon(symbol: SymbolDetail) {
   return 'info';
 }
 
-function TableOfContentsItem({ symbol, onSelectSymbol }: TableOfContentsItemProps) {
+function TableOfContentsItem({ symbol, selectSymbol }: TableOfContentsItemProps) {
   const icon = getSymbolIcon(symbol);
 
   function handleClick() {
-    onSelectSymbol(symbol.name);
+    selectSymbol(symbol.name);
   }
 
   return (
@@ -38,7 +38,7 @@ function TableOfContentsItem({ symbol, onSelectSymbol }: TableOfContentsItemProp
 }
 
 export const TableOfContents = ({ symbols }: { symbols: SymbolDetail[] }) => {
-  function handleSelectSymbol(id: string) {
+  function selectSymbol(id: string) {
     const el = document.getElementById(id);
     if (el) {
       el.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -51,7 +51,7 @@ export const TableOfContents = ({ symbols }: { symbols: SymbolDetail[] }) => {
         <h4 className="font-sans text-2xs font-bold text-gray-400 uppercase tracking-widest mb-6">On This Page</h4>
         <ul className="space-y-3 relative border-l border-gray-200 ml-1">
           {symbols.map((symbol) => (
-            <TableOfContentsItem key={symbol.name} symbol={symbol} onSelectSymbol={handleSelectSymbol} />
+            <TableOfContentsItem key={symbol.name} symbol={symbol} selectSymbol={selectSymbol} />
           ))}
         </ul>
       </div>

--- a/src/pages/code-doc/features/CodeDocView/ui/TextbookCodeBlock.tsx
+++ b/src/pages/code-doc/features/CodeDocView/ui/TextbookCodeBlock.tsx
@@ -7,25 +7,25 @@ export const TextbookCodeBlock: React.FC<{
   code: string;
   lang?: string;
   startLine?: number;
-  onLineClick?: (lineNumber: number) => void;
-}> = ({ code, lang = 'typescript', startLine = 1, onLineClick }) => {
+  clickLine?: (lineNumber: number) => void;
+}> = ({ code, lang = 'typescript', startLine = 1, clickLine }) => {
   const [hoveredLine, setHoveredLine] = useState<number | null>(null);
 
   const lineCount = code.split('\n').length;
   const codeLines = code.split('\n');
-  const canClickLine = Boolean(onLineClick);
+  const canClickLine = Boolean(clickLine);
 
-  function handleHoverLine(lineIndex: number) {
+  function hoverLine(lineIndex: number) {
     setHoveredLine(lineIndex);
   }
 
-  function handleLeaveLine() {
+  function leaveLine() {
     setHoveredLine(null);
   }
 
-  function handleLineClick(lineNumber: number) {
-    if (onLineClick) {
-      onLineClick(lineNumber);
+  function selectLine(lineNumber: number) {
+    if (clickLine) {
+      clickLine(lineNumber);
     }
   }
 
@@ -43,9 +43,9 @@ export const TextbookCodeBlock: React.FC<{
                 lineNumber={lineNum}
                 isHovered={isHovered}
                 canClick={canClickLine}
-                hoverLine={handleHoverLine}
-                leaveLine={handleLeaveLine}
-                clickLine={handleLineClick}
+                hoverLine={hoverLine}
+                leaveLine={leaveLine}
+                clickLine={selectLine}
               />
             );
           })}
@@ -63,9 +63,9 @@ export const TextbookCodeBlock: React.FC<{
                 lineNumber={startLine + i}
                 isHovered={isHovered}
                 canClick={canClickLine}
-                hoverLine={handleHoverLine}
-                leaveLine={handleLeaveLine}
-                clickLine={handleLineClick}
+                hoverLine={hoverLine}
+                leaveLine={leaveLine}
+                clickLine={selectLine}
               />
             );
           })}

--- a/src/pages/dead-code/features/DeadCodePanel/ui/DeadCodeCategoryHeader.tsx
+++ b/src/pages/dead-code/features/DeadCodePanel/ui/DeadCodeCategoryHeader.tsx
@@ -25,7 +25,7 @@ export const DeadCodeCategoryHeader = React.forwardRef<
 
   const isExpanded = expandedCategories[categoryKey];
 
-  function handleToggleCategory() {
+  function toggleCategory() {
     setExpandedCategories((prev) => ({
       ...prev,
       [categoryKey]: !prev[categoryKey],
@@ -59,7 +59,7 @@ export const DeadCodeCategoryHeader = React.forwardRef<
         itemCount={items.length}
         categoryKey={categoryKey}
         isExpanded={isExpanded}
-        toggleCategory={handleToggleCategory}
+        toggleCategory={toggleCategory}
       />
 
       <CategoryCheckbox items={items} />

--- a/src/pages/dead-code/features/DeadCodePanel/ui/DeadCodePanel.tsx
+++ b/src/pages/dead-code/features/DeadCodePanel/ui/DeadCodePanel.tsx
@@ -29,10 +29,6 @@ export function DeadCodePanel() {
     setShowPromptDialog(true);
   }
 
-  function handlePromptOpenChange(nextOpen: boolean) {
-    setShowPromptDialog(nextOpen);
-  }
-
   return (
     <div className="flex h-full w-full overflow-hidden">
       {/* 좌측: Dead Code Panel */}
@@ -65,7 +61,7 @@ export function DeadCodePanel() {
         {deadCodeResults && (
           <RefactoringPromptDialog
             open={showPromptDialog}
-            onOpenChange={handlePromptOpenChange}
+            changeOpen={setShowPromptDialog}
             selectedItemKeys={selectedItems}
             deadCodeResults={deadCodeResults}
           />

--- a/src/pages/git/features/GitPanel/ui/GitChangeAllButton.tsx
+++ b/src/pages/git/features/GitPanel/ui/GitChangeAllButton.tsx
@@ -1,0 +1,23 @@
+import { Minus, Plus } from 'lucide-react';
+import { Button } from '@/shared/ui/Button';
+
+interface GitChangeAllButtonProps {
+  allAction: 'stage' | 'unstage';
+  toggleAll: () => void;
+}
+
+export function GitChangeAllButton({ allAction, toggleAll }: GitChangeAllButtonProps) {
+  const AllActionIcon = allAction === 'stage' ? Plus : Minus;
+  const allActionLabel = allAction === 'stage' ? 'Stage All' : 'Unstage All';
+
+  function handleClick() {
+    toggleAll();
+  }
+
+  return (
+    <Button variant="ghost" size="sm" className="h-5 px-1 text-2xs" onClick={handleClick}>
+      <AllActionIcon size={10} className="mr-0.5" />
+      {allActionLabel}
+    </Button>
+  );
+}

--- a/src/pages/git/features/GitPanel/ui/GitChangeSection.tsx
+++ b/src/pages/git/features/GitPanel/ui/GitChangeSection.tsx
@@ -1,8 +1,7 @@
-import { ChevronDown, ChevronRight, Minus, Plus } from 'lucide-react';
-import type React from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
-import { Button } from '@/shared/ui/Button';
 import type { FileChange } from '../model/types';
+import { GitChangeAllButton } from './GitChangeAllButton';
 import { GitFileChangeButton } from './GitFileChangeButton';
 
 export function GitChangeSection({
@@ -21,38 +20,25 @@ export function GitChangeSection({
   toggleFileStage: (path: string) => void;
 }) {
   const [isExpanded, setIsExpanded] = useState(true);
-  const AllActionIcon = allAction === 'stage' ? Plus : Minus;
-  const allActionLabel = allAction === 'stage' ? 'Stage All' : 'Unstage All';
 
   function handleSectionClick() {
     setIsExpanded(!isExpanded);
   }
 
-  function handleToggleAllClick(e: React.MouseEvent) {
-    e.stopPropagation();
-    toggleAll();
-  }
-
   return (
     <div className="space-y-1">
-      <button
-        onClick={handleSectionClick}
-        className="w-full flex items-center gap-1 px-1 py-1 hover:bg-white/5 rounded transition-colors"
-      >
-        {isExpanded ? (
-          <ChevronDown size={14} className="text-text-muted" />
-        ) : (
-          <ChevronRight size={14} className="text-text-muted" />
-        )}
-        <span className="text-xs font-medium text-text-primary flex-1 text-left">{title}</span>
-        <span className="text-xs text-text-muted">{files.length}</span>
-        {files.length > 0 && (
-          <Button variant="ghost" size="sm" className="h-5 px-1 text-2xs" onClick={handleToggleAllClick}>
-            <AllActionIcon size={10} className="mr-0.5" />
-            {allActionLabel}
-          </Button>
-        )}
-      </button>
+      <div className="w-full flex items-center gap-1 px-1 py-1 hover:bg-white/5 rounded transition-colors">
+        <button type="button" onClick={handleSectionClick} className="min-w-0 flex flex-1 items-center gap-1 text-left">
+          {isExpanded ? (
+            <ChevronDown size={14} className="text-text-muted" />
+          ) : (
+            <ChevronRight size={14} className="text-text-muted" />
+          )}
+          <span className="text-xs font-medium text-text-primary flex-1 truncate">{title}</span>
+          <span className="text-xs text-text-muted">{files.length}</span>
+        </button>
+        {files.length > 0 && <GitChangeAllButton allAction={allAction} toggleAll={toggleAll} />}
+      </div>
 
       {isExpanded && (
         <div className="ml-2 space-y-0.5">

--- a/src/pages/json-explorer/features/JsonExplorer/ui/DetailsPanelToggleButton.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/DetailsPanelToggleButton.tsx
@@ -1,0 +1,27 @@
+import { PanelRightClose, PanelRightOpen } from 'lucide-react';
+
+interface DetailsPanelToggleButtonProps {
+  rightPanelOpen: boolean;
+  changeRightPanelOpen: (nextRightPanelOpen: boolean) => void;
+}
+
+export function DetailsPanelToggleButton({ rightPanelOpen, changeRightPanelOpen }: DetailsPanelToggleButtonProps) {
+  function handleClick() {
+    changeRightPanelOpen(!rightPanelOpen);
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className="p-1.5 hover:bg-bg-elevated rounded transition-colors"
+      aria-label="Toggle details panel"
+      title={rightPanelOpen ? 'Close details panel' : 'Open details panel'}
+    >
+      {rightPanelOpen ? (
+        <PanelRightClose size={16} className="text-warm-400" />
+      ) : (
+        <PanelRightOpen size={16} className="text-text-tertiary" />
+      )}
+    </button>
+  );
+}

--- a/src/pages/json-explorer/features/JsonExplorer/ui/FormatHeadersCheckbox.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/FormatHeadersCheckbox.tsx
@@ -1,0 +1,24 @@
+import { Checkbox } from '@/shared/ui/Checkbox';
+
+interface FormatHeadersCheckboxProps {
+  formatHeaders: boolean;
+  changeFormatHeaders: (nextFormatHeaders: boolean) => void;
+}
+
+export function FormatHeadersCheckbox({ formatHeaders, changeFormatHeaders }: FormatHeadersCheckboxProps) {
+  function handleCheckedChange(checked: boolean | 'indeterminate') {
+    changeFormatHeaders(checked === true);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Checkbox id="format-headers" checked={formatHeaders} onCheckedChange={handleCheckedChange} />
+      <label
+        htmlFor="format-headers"
+        className="text-2xs text-text-secondary cursor-pointer select-none hover:text-text-primary transition-colors"
+      >
+        Format Headers
+      </label>
+    </div>
+  );
+}

--- a/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerColumnItem.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerColumnItem.tsx
@@ -1,0 +1,22 @@
+interface JsonExplorerColumnItemProps {
+  column: string;
+  selectColumn?: (column: string) => void;
+  scrollToColumn?: (column: string) => void;
+}
+
+export function JsonExplorerColumnItem({ column, selectColumn, scrollToColumn }: JsonExplorerColumnItemProps) {
+  function handleClick() {
+    selectColumn?.(column);
+    scrollToColumn?.(column);
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2 px-3 py-0.5 text-2xs cursor-pointer hover:bg-warm-500/10 transition-colors"
+      onClick={handleClick}
+    >
+      <div className="w-1 h-1 rounded-full bg-warm-300 shrink-0" />
+      <span className="font-mono text-text-secondary truncate">{column}</span>
+    </div>
+  );
+}

--- a/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerColumnsSection.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerColumnsSection.tsx
@@ -1,36 +1,12 @@
 import { ChevronDown, ChevronRight, Columns } from 'lucide-react';
 import { useState } from 'react';
 import { ScrollArea } from '@/shared/ui/ScrollArea';
+import { JsonExplorerColumnItem } from './JsonExplorerColumnItem';
 
 interface JsonExplorerColumnsSectionProps {
   columns: string[];
   selectColumn?: (columnKey: string) => void;
   scrollToColumn?: (columnKey: string) => void;
-}
-
-function ColumnItem({
-  column,
-  selectColumn,
-  scrollToColumn,
-}: {
-  column: string;
-  selectColumn?: (column: string) => void;
-  scrollToColumn?: (column: string) => void;
-}) {
-  function handleClick() {
-    selectColumn?.(column);
-    scrollToColumn?.(column);
-  }
-
-  return (
-    <div
-      className="flex items-center gap-2 px-3 py-0.5 text-2xs cursor-pointer hover:bg-warm-500/10 transition-colors"
-      onClick={handleClick}
-    >
-      <div className="w-1 h-1 rounded-full bg-warm-300 shrink-0" />
-      <span className="font-mono text-text-secondary truncate">{column}</span>
-    </div>
-  );
 }
 
 export function JsonExplorerColumnsSection({ columns, selectColumn, scrollToColumn }: JsonExplorerColumnsSectionProps) {
@@ -56,7 +32,12 @@ export function JsonExplorerColumnsSection({ columns, selectColumn, scrollToColu
         <ScrollArea className="flex-1">
           <div className="py-1">
             {columns.map((column) => (
-              <ColumnItem key={column} column={column} selectColumn={selectColumn} scrollToColumn={scrollToColumn} />
+              <JsonExplorerColumnItem
+                key={column}
+                column={column}
+                selectColumn={selectColumn}
+                scrollToColumn={scrollToColumn}
+              />
             ))}
           </div>
         </ScrollArea>

--- a/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerDataSourceOption.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerDataSourceOption.tsx
@@ -1,0 +1,44 @@
+import type { LucideIcon } from 'lucide-react';
+import type { DataSource } from '../lib/loadTestData';
+
+interface JsonExplorerDataSourceOptionProps {
+  active: boolean;
+  icon: LucideIcon;
+  label: string;
+  mono?: boolean;
+  source?: DataSource;
+  changeDataSource: (source: DataSource) => void;
+  openCustomJson: () => void;
+}
+
+export function JsonExplorerDataSourceOption({
+  active,
+  icon: Icon,
+  label,
+  mono = false,
+  source,
+  changeDataSource,
+  openCustomJson,
+}: JsonExplorerDataSourceOptionProps) {
+  function handleClick() {
+    if (source) {
+      changeDataSource(source);
+      return;
+    }
+
+    openCustomJson();
+  }
+
+  return (
+    <div
+      className={`flex items-center gap-2 px-3 py-1.5 text-2xs cursor-pointer transition-colors ${
+        active ? 'bg-warm-500/20 text-text-primary' : 'text-text-secondary hover:bg-warm-500/10'
+      }`}
+      onClick={handleClick}
+    >
+      <div className={`w-1 h-1 rounded-full shrink-0 ${active ? 'bg-warm-400' : 'bg-text-tertiary'}`} />
+      <Icon size={12} className="shrink-0" />
+      <span className={`${mono ? 'font-mono ' : ''}truncate`}>{label}</span>
+    </div>
+  );
+}

--- a/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerDataSourceSection.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerDataSourceSection.tsx
@@ -1,51 +1,12 @@
-import { ChevronDown, ChevronRight, Database, FileJson, type LucideIcon, Pencil } from 'lucide-react';
+import { ChevronDown, ChevronRight, Database, FileJson, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import type { DataSource } from '../lib/loadTestData';
+import { JsonExplorerDataSourceOption } from './JsonExplorerDataSourceOption';
 
 interface JsonExplorerDataSourceSectionProps {
   dataSource: DataSource;
   changeDataSource: (source: DataSource) => void;
   openCustomJson: () => void;
-}
-
-function DataSourceOption({
-  active,
-  icon: Icon,
-  label,
-  mono = false,
-  source,
-  changeDataSource,
-  openCustomJson,
-}: {
-  active: boolean;
-  icon: LucideIcon;
-  label: string;
-  mono?: boolean;
-  source?: DataSource;
-  changeDataSource: (source: DataSource) => void;
-  openCustomJson: () => void;
-}) {
-  function handleClick() {
-    if (source) {
-      changeDataSource(source);
-      return;
-    }
-
-    openCustomJson();
-  }
-
-  return (
-    <div
-      className={`flex items-center gap-2 px-3 py-1.5 text-2xs cursor-pointer transition-colors ${
-        active ? 'bg-warm-500/20 text-text-primary' : 'text-text-secondary hover:bg-warm-500/10'
-      }`}
-      onClick={handleClick}
-    >
-      <div className={`w-1 h-1 rounded-full shrink-0 ${active ? 'bg-warm-400' : 'bg-text-tertiary'}`} />
-      <Icon size={12} className="shrink-0" />
-      <span className={`${mono ? 'font-mono ' : ''}truncate`}>{label}</span>
-    </div>
-  );
 }
 
 export function JsonExplorerDataSourceSection({
@@ -72,7 +33,7 @@ export function JsonExplorerDataSourceSection({
 
       {isExpanded && (
         <div className="py-1">
-          <DataSourceOption
+          <JsonExplorerDataSourceOption
             active={dataSource === 'test.json'}
             icon={FileJson}
             label="test.json"
@@ -81,7 +42,7 @@ export function JsonExplorerDataSourceSection({
             changeDataSource={changeDataSource}
             openCustomJson={openCustomJson}
           />
-          <DataSourceOption
+          <JsonExplorerDataSourceOption
             active={dataSource === 'test2.json'}
             icon={FileJson}
             label="test2.json"
@@ -90,7 +51,7 @@ export function JsonExplorerDataSourceSection({
             changeDataSource={changeDataSource}
             openCustomJson={openCustomJson}
           />
-          <DataSourceOption
+          <JsonExplorerDataSourceOption
             active={dataSource === 'custom'}
             icon={Pencil}
             label="Custom JSON..."

--- a/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerHeader.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/JsonExplorerHeader.tsx
@@ -1,6 +1,6 @@
-import { PanelRightClose, PanelRightOpen } from 'lucide-react';
-import { Checkbox } from '@/shared/ui/Checkbox';
+import { DetailsPanelToggleButton } from './DetailsPanelToggleButton';
 import { ExportButton } from './ExportButton';
+import { FormatHeadersCheckbox } from './FormatHeadersCheckbox';
 
 interface JsonExplorerHeaderProps {
   formatHeaders: boolean;
@@ -17,14 +17,6 @@ export function JsonExplorerHeader({
   rightPanelOpen,
   changeRightPanelOpen,
 }: JsonExplorerHeaderProps) {
-  function handleFormatHeadersCheckedChange(checked: boolean | 'indeterminate') {
-    changeFormatHeaders(checked === true);
-  }
-
-  function handleRightPanelToggle() {
-    changeRightPanelOpen(!rightPanelOpen);
-  }
-
   return (
     <div className="px-4 py-2.5 border-b border-border-DEFAULT bg-bg-deep shrink-0">
       <div className="flex items-center justify-between">
@@ -34,30 +26,11 @@ export function JsonExplorerHeader({
         </div>
 
         <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2">
-            <Checkbox id="format-headers" checked={formatHeaders} onCheckedChange={handleFormatHeadersCheckedChange} />
-            <label
-              htmlFor="format-headers"
-              className="text-2xs text-text-secondary cursor-pointer select-none hover:text-text-primary transition-colors"
-            >
-              Format Headers
-            </label>
-          </div>
+          <FormatHeadersCheckbox formatHeaders={formatHeaders} changeFormatHeaders={changeFormatHeaders} />
 
           <ExportButton data={exportData} filename="json-export" />
 
-          <button
-            onClick={handleRightPanelToggle}
-            className="p-1.5 hover:bg-bg-elevated rounded transition-colors"
-            aria-label="Toggle details panel"
-            title={rightPanelOpen ? 'Close details panel' : 'Open details panel'}
-          >
-            {rightPanelOpen ? (
-              <PanelRightClose size={16} className="text-warm-400" />
-            ) : (
-              <PanelRightOpen size={16} className="text-text-tertiary" />
-            )}
-          </button>
+          <DetailsPanelToggleButton rightPanelOpen={rightPanelOpen} changeRightPanelOpen={changeRightPanelOpen} />
         </div>
       </div>
     </div>

--- a/src/pages/json-explorer/features/JsonExplorer/ui/JsonHighlighter.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/JsonHighlighter.tsx
@@ -1,5 +1,4 @@
 import { Copy } from 'lucide-react';
-import type React from 'react';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 
@@ -73,13 +72,14 @@ function renderHighlightedJsonLine(text: string): ReactNode[] {
 interface JsonHighlighterLineProps {
   line: { text: string; path: string | null; lineNumber: number };
   copiedPath: string | null;
-  copyPath: (path: string, e: React.MouseEvent) => void;
+  copyPath: (path: string) => void;
 }
 
 function JsonHighlighterLine({ line, copiedPath, copyPath }: JsonHighlighterLineProps) {
   function handleCopyPathClick(e: React.MouseEvent) {
     if (line.path) {
-      copyPath(line.path, e);
+      e.stopPropagation();
+      copyPath(line.path);
     }
   }
 
@@ -159,8 +159,7 @@ export function JsonHighlighter({ json }: { json: string }) {
     return result;
   }, [json]);
 
-  async function handleCopyPath(path: string, e: React.MouseEvent) {
-    e.stopPropagation();
+  async function copyPath(path: string) {
     try {
       await navigator.clipboard.writeText(path);
       setCopiedPath(path);
@@ -173,7 +172,7 @@ export function JsonHighlighter({ json }: { json: string }) {
   return (
     <div className="font-mono text-2xs">
       {lines.map((line) => (
-        <JsonHighlighterLine key={line.lineNumber} line={line} copiedPath={copiedPath} copyPath={handleCopyPath} />
+        <JsonHighlighterLine key={line.lineNumber} line={line} copiedPath={copiedPath} copyPath={copyPath} />
       ))}
     </div>
   );

--- a/src/pages/json-explorer/features/JsonExplorer/ui/SchemaFieldRow.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/SchemaFieldRow.tsx
@@ -7,7 +7,7 @@ interface SchemaFieldRowProps {
   displayType: string;
   typeColor: string;
   copiedPath: string | null;
-  copyPath: (path: string, e: React.MouseEvent) => void;
+  copyPath: (path: string) => void;
 }
 
 export function SchemaFieldRow({
@@ -20,7 +20,8 @@ export function SchemaFieldRow({
   copyPath,
 }: SchemaFieldRowProps) {
   function handleCopyPathClick(e: React.MouseEvent) {
-    copyPath(fullPath, e);
+    e.stopPropagation();
+    copyPath(fullPath);
   }
 
   return (

--- a/src/pages/json-explorer/features/JsonExplorer/ui/SchemaInterfaceItem.tsx
+++ b/src/pages/json-explorer/features/JsonExplorer/ui/SchemaInterfaceItem.tsx
@@ -15,8 +15,7 @@ export function SchemaInterfaceItem({
   const [isExpanded, setIsExpanded] = useState(false);
   const [copiedPath, setCopiedPath] = useState<string | null>(null);
 
-  async function handleCopyPath(path: string, e: React.MouseEvent) {
-    e.stopPropagation();
+  async function copyPath(path: string) {
     try {
       await navigator.clipboard.writeText(path);
       setCopiedPath(path);
@@ -105,7 +104,7 @@ export function SchemaInterfaceItem({
                 displayType={displayType}
                 typeColor={typeColor}
                 copiedPath={copiedPath}
-                copyPath={handleCopyPath}
+                copyPath={copyPath}
               />
             );
           })}


### PR DESCRIPTION
## Summary
- split hidden leaf controls out of broad feature/page UI containers
- rename non-event command callbacks so only leaf DOM/event handlers keep handle* names
- reduce 2+ handle* feature/page UI scan candidates from 43 after #40 to 27, leaving cohesive leaf interactions intact

## Kept by SRP judgment
Remaining candidates are leaf interactions or keyboard/canvas scopes where splitting would add indirection: token hover/click segments, row/chip controls, modal submit/cancel/change, resize mouse/touch handles, and hook-backed content search actions.

## Verification
- npm run lint
- npm run build